### PR TITLE
chore: add support to different platforms to db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - db
 
   db:
+    platform: linux/x86_64
     image: mysql:5.7
     container_name: meican-db
     volumes:


### PR DESCRIPTION
- Ao rodar o MEICAN em um Mac arquitetura M1, tive problemas com o MySQL. Basicamente, é preciso setar manualmente a `platform` para que seja fixada a arquitetura Linux