### PR TITLE
feat: allow client certificates on NSI

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -6,11 +6,16 @@ This step is set some parameters in order to configure the application.
 
 Location: config/params.php
 
-Located on certificates folder on project root, the application certificate must be defined:
+To properly configure the certificates for the application, you need to specify the certificate filename, certificate key, and optionally enable client certificate authentication for mutual TLS. Additionally, you can provide a certificate password for encrypted certificates.
+
+The certificates must be located in the certificates folder in the project root. Example in `config.params.php`: 
 
 ```
-'certificate.filename' => 'meican.pem',
-'certificate.pass' => '#CERTIFICATE-PASSWORD#',    
+'certificate.filename' => 'meican_cert.pem',       // Certificate file (PEM format)
+'certificate.keyfile' => 'meican_key.pem',         // Certificate key file (PEM format)
+'certificate.pass' => '#CERTIFICATE-PASSWORD#',    // Password for the certificate
+'certificate.ca_file' => 'meican_ca.pem',          // CA certificate file for validating server (PEM format)
+'certificate.use_client_cert' => true,             // Enable mutual TLS (true/false)
 ```
 
 By default the fake provider is enabled. Disable this feature setting the param below:

--- a/modules/nsi/NSIParser.php
+++ b/modules/nsi/NSIParser.php
@@ -144,21 +144,26 @@ class NSIParser {
             CURLOPT_URL => $this->url,
         );
 
-        $use_client_cert = Yii::$app->params['certificate.use_client_cert'];
+        $use_client_cert = isset(Yii::$app->params['certificate.use_client_cert']) && Yii::$app->params['certificate.use_client_cert'];
 
         if ($use_client_cert) {
             $cert_path = realpath(__DIR__."/../../certificates/".\Yii::$app->params['certificate.filename']);
             $certkey_path = realpath(__DIR__."/../../certificates/".\Yii::$app->params['certificate.keyfile']);
-            $cert_pass = Yii::$app->params['certificate.pass'];
             $cert_ca = realpath(__DIR__."/../../certificates/".\Yii::$app->params['certificate.ca_file']);
 
             $options = $options + array(
                 CURLOPT_SSLCERTTYPE      => 'PEM',
                 CURLOPT_SSLCERT          => $cert_path,
                 CURLOPT_SSLKEY           => $certkey_path,
-                CURLOPT_SSLCERTPASSWD    => 'meicantest', 
                 CURLOPT_CAINFO           => $cert_ca,
             );
+
+            if (isset(Yii::$app->params['certificate.pass'])) {
+                $options = $options + array(
+                    CURLOPT_SSLCERTPASSWD => Yii::$app->params['certificate.pass'], 
+                );
+            }
+
             Yii::trace("[NSI Parser] Using cert files: $cert_path | $certkey_path | $cert_ca");
         }
 
@@ -179,7 +184,7 @@ class NSIParser {
             return true;
         } else {
             Yii::trace("[NSI Parser] output is null");
-            Yii::trace("[NSI Parser] curl response error = $output_error");
+            Yii::error("[NSI Parser] curl response error = $output_error");
             return false;
         };
     }

--- a/modules/nsi/NSIParser.php
+++ b/modules/nsi/NSIParser.php
@@ -94,7 +94,9 @@ class NSIParser {
             if($docContentNode->item(0)->getAttribute("contentType") == "application/x-gzip" && 
                     $docContentNode->item(0)->getAttribute('contentTransferEncoding') == "base64") {
                 $contentDOM = new \DOMDocument();
-                $contentDOM->loadXML(gzdecode(base64_decode($docContentNode->item(0)->nodeValue)));
+                $decoded_data = gzdecode(base64_decode($docContentNode->item(0)->nodeValue));
+                Yii::trace("Decoded base64|Gzip:\n $decoded_data");
+                $contentDOM->loadXML($decoded_data);
                 switch ($docTypeNode->item(0)->nodeValue) {
                     case "vnd.ogf.nsi.topology.v2+xml":
                         $xmlns = "http://schemas.ogf.org/nml/2013/05/base#";
@@ -127,30 +129,59 @@ class NSIParser {
     }
 
     function loadFile($url) {
+        Yii::trace("[NSI Parser] Loading file in URL: $url");
         $this->url = $url;
         
         $ch = curl_init();
 
         $options = array(
-                CURLOPT_RETURNTRANSFER => true,
-                CURLOPT_FOLLOWLOCATION => true,
-                CURLOPT_SSL_VERIFYHOST => false,
-                CURLOPT_SSL_VERIFYPEER => false,
-                CURLOPT_CONNECTTIMEOUT => 5,
-                CURLOPT_USERAGENT => 'Meican',
-                CURLOPT_URL => $this->url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_SSL_VERIFYHOST => false,
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_CONNECTTIMEOUT => 5,
+            CURLOPT_USERAGENT => 'Meican',
+            CURLOPT_URL => $this->url,
         );
+
+        $use_client_cert = Yii::$app->params['certificate.use_client_cert'];
+
+        if ($use_client_cert) {
+            $cert_path = realpath(__DIR__."/../../certificates/".\Yii::$app->params['certificate.filename']);
+            $certkey_path = realpath(__DIR__."/../../certificates/".\Yii::$app->params['certificate.keyfile']);
+            $cert_pass = Yii::$app->params['certificate.pass'];
+            $cert_ca = realpath(__DIR__."/../../certificates/".\Yii::$app->params['certificate.ca_file']);
+
+            $options = $options + array(
+                CURLOPT_SSLCERTTYPE      => 'PEM',
+                CURLOPT_SSLCERT          => $cert_path,
+                CURLOPT_SSLKEY           => $certkey_path,
+                CURLOPT_SSLCERTPASSWD    => 'meicantest', 
+                CURLOPT_CAINFO           => $cert_ca,
+            );
+            Yii::trace("[NSI Parser] Using cert files: $cert_path | $certkey_path | $cert_ca");
+        }
+
+        $arr_str = print_r($options, true);
+        Yii::trace("[NSI Parser] options array : $arr_str");
 
         curl_setopt_array($ch , $options);
 
         $output = curl_exec($ch);
+        $output_info = curl_getinfo($ch);
+        $output_error = curl_error($ch);
+        $output_info_str = print_r($output_info, true);
+        Yii::trace("[NSI Parser] curl response info = $output_info_str");
         curl_close($ch);
-
         if($output != null) {
             //  echo $output;
             $this->loadXml($output);
             return true;
-        } else return false;
+        } else {
+            Yii::trace("[NSI Parser] output is null");
+            Yii::trace("[NSI Parser] curl response error = $output_error");
+            return false;
+        };
     }
     
     function getData() {


### PR DESCRIPTION
This feature enables mutual authentication when loading NSI/NSA files for discoveries.

In order to use it, you need to set the following properties on `config/params.php` file:
```
   'certificate.use_client_cert' => true,
    'certificate.filename' => "client_cert.pem",
    'certificate.keyfile' => "client_key.pem",	
    'certificate.pass' => "your_password",	
    'certificate.ca_file' => "ca_cert.pem",
```